### PR TITLE
feat(android): 로그아웃 연동

### DIFF
--- a/composeApp/src/androidMain/kotlin/good/space/runnershi/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/good/space/runnershi/MainActivity.kt
@@ -80,17 +80,19 @@ class MainActivity : ComponentActivity() {
                 })
             }
         }
-        val authRepository = AuthRepositoryImpl(authHttpClient, baseUrl)
         
         // 4. ApiClient 생성 (인증 플러그인 포함)
         val apiClient = ApiClient(tokenStorage, baseUrl)
+        
+        // 5. AuthRepository 생성 (로그아웃은 인증이 필요하므로 apiClient.httpClient 사용)
+        val authRepository = AuthRepositoryImpl(authHttpClient, baseUrl, apiClient.httpClient)
         val serviceController = AndroidServiceController(this)
 
         // 5. RunRepository 생성
         // TODO: 서버 API가 준비되면 RunRepositoryImpl(apiClient)로 변경
         val runRepository = MockRunRepository() // 테스트용 Mock 데이터 사용
         val runningViewModel = RunningViewModel(serviceController, runRepository)
-        val mainViewModel = MainViewModel(tokenStorage, apiClient)
+        val mainViewModel = MainViewModel(tokenStorage, apiClient, authRepository)
         val loginViewModel = LoginViewModel(authRepository, tokenStorage)
         val signUpViewModel = SignUpViewModel(authRepository, tokenStorage)
         

--- a/shared/src/commonMain/kotlin/good/space/runnershi/repository/AuthRepository.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/repository/AuthRepository.kt
@@ -7,4 +7,5 @@ import good.space.runnershi.model.dto.auth.SignUpRequest
 interface AuthRepository {
     suspend fun login(request: LoginRequest): Result<LoginResponse>
     suspend fun signUp(request: SignUpRequest): Result<LoginResponse>
+    suspend fun logout(): Result<Unit>
 }

--- a/shared/src/commonMain/kotlin/good/space/runnershi/repository/AuthRepositoryImpl.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/repository/AuthRepositoryImpl.kt
@@ -10,10 +10,12 @@ import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.http.isSuccess
 
 class AuthRepositoryImpl(
-    private val httpClient: HttpClient,
-    private val baseUrl: String
+    private val httpClient: HttpClient, // 인증 없는 요청용 (login, signup)
+    private val baseUrl: String,
+    private val authenticatedHttpClient: HttpClient? = null // 인증 필요한 요청용 (logout) - 선택적
 ) : AuthRepository {
 
     override suspend fun login(request: LoginRequest): Result<LoginResponse> {
@@ -62,6 +64,23 @@ class AuthRepositoryImpl(
                 Result.success(tokenResponse)
             } else {
                 Result.failure(Exception("회원가입은 성공했으나 자동 로그인 실패: ${loginResponse.status}"))
+            }
+        } catch (e: Exception) {
+            Result.failure(e)
+        }
+    }
+
+    override suspend fun logout(): Result<Unit> {
+        return try {
+            // 인증이 필요한 요청이므로 authenticatedHttpClient 사용 (없으면 httpClient 사용)
+            val client = authenticatedHttpClient ?: httpClient
+            val response = client.post("$baseUrl/api/v1/auth/logout")
+            
+            // 2XX 상태코드면 성공 (200 OK 또는 204 NO CONTENT 등)
+            if (response.status.isSuccess()) {
+                Result.success(Unit)
+            } else {
+                Result.failure(Exception("로그아웃 실패: ${response.status}"))
             }
         } catch (e: Exception) {
             Result.failure(e)

--- a/shared/src/commonMain/kotlin/good/space/runnershi/repository/MockAuthRepository.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/repository/MockAuthRepository.kt
@@ -22,5 +22,11 @@ class MockAuthRepository : AuthRepository {
             )
         )
     }
+
+    override suspend fun logout(): Result<Unit> {
+        delay(500) // 네트워크 지연 시뮬레이션
+        println("📡 [Mock Server] Logout")
+        return Result.success(Unit)
+    }
 }
 


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [ ] **Server**
- [x] **Android**
- [ ] **iOS**

## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
서버에서 구현한 로그아웃 API와 연동했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #33 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
