### PR TITLE
feat(android): 서버에 저장될 러닝의 최소 조건을 3분과 300m로 수정

### DIFF
--- a/composeApp/src/androidMain/kotlin/good/space/runnershi/ui/component/ShortRunWarningDialog.kt
+++ b/composeApp/src/androidMain/kotlin/good/space/runnershi/ui/component/ShortRunWarningDialog.kt
@@ -33,7 +33,7 @@ fun ShortRunWarningDialog(
         },
         text = {
             Text(
-                text = "러닝이 너무 짧아서 저장되지 않았어요.\n1분 이상 달렸으면서 100m 이상 달렸을 경우에만 기록이 저장돼요.",
+                text = "러닝이 너무 짧아서 저장되지 않았어요.\n3분 이상 달렸으면서 300m 이상 달렸을 경우에만 기록이 저장돼요.",
                 textAlign = TextAlign.Center
             )
         },

--- a/composeApp/src/androidMain/kotlin/good/space/runnershi/ui/screen/RunResultScreen.kt
+++ b/composeApp/src/androidMain/kotlin/good/space/runnershi/ui/screen/RunResultScreen.kt
@@ -35,7 +35,7 @@ fun RunResultScreen(
     
     // 저장 조건 체크 (ViewModel의 로직과 동일하게 유지)
     val isShortRun = remember(result) {
-        result.totalDistanceMeters < 100.0 || result.duration.inWholeSeconds < 60
+        result.totalDistanceMeters < 300.0 || result.duration.inWholeSeconds < 180
     }
 
     // 화면 진입 시 전체 경로가 보이도록 줌 아웃 (LatLngBounds)
@@ -192,7 +192,7 @@ fun NotSavedWarningBanner() {
                 )
                 Spacer(modifier = Modifier.height(4.dp))
                 Text(
-                    text = "유효한 러닝 기록(거리 100m 이상, 시간 1분 이상)만 히스토리에 저장됩니다.",
+                    text = "유효한 러닝 기록(거리 300m 이상, 시간 3분 이상)만 히스토리에 저장됩니다.",
                     style = MaterialTheme.typography.bodyMedium,
                     color = MaterialTheme.colorScheme.onErrorContainer
                 )

--- a/shared/src/commonMain/kotlin/good/space/runnershi/viewmodel/RunningViewModel.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/viewmodel/RunningViewModel.kt
@@ -112,7 +112,7 @@ class RunningViewModel(
     
     // 서버 전송 조건 검사
     private fun shouldUploadToServer(result: RunResult): Boolean {
-        return result.totalDistanceMeters >= 100.0 && result.duration.inWholeSeconds >= 60
+        return result.totalDistanceMeters >= 300.0 && result.duration.inWholeSeconds >= 180
     }
 
     private fun createRunResultSnapshot(): RunResult {


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [ ] **Server**
- [x] **Android**
- [ ] **iOS**

## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
서버에 저장될 러닝의 최소 조건을 수정했습니다.
- 최소 시간: 1분 -> 3분
- 최소 거리: 100m -> 300m

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #40 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
