### PR TITLE
feat(android): 2회 이상 차량 이동 감지시 러닝을 종료하도록 구현

### DIFF
--- a/shared/src/commonMain/kotlin/good/space/runnershi/state/RunningStateManager.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/state/RunningStateManager.kt
@@ -32,6 +32,10 @@ object RunningStateManager {
     private val _pauseType = MutableStateFlow(PauseType.NONE)
     val pauseType: StateFlow<PauseType> = _pauseType.asStateFlow()
 
+    // [New] 차량 감지 경고 횟수 (0부터 시작)
+    private val _vehicleWarningCount = MutableStateFlow(0)
+    val vehicleWarningCount: StateFlow<Int> = _vehicleWarningCount.asStateFlow()
+
     // 상태 업데이트 함수들 (Service에서 호출)
     fun updateLocation(location: LocationModel, distanceDelta: Double) {
         _currentLocation.value = location
@@ -67,6 +71,13 @@ object RunningStateManager {
     }
     
     /**
+     * 차량 경고 횟수 증가
+     */
+    fun incrementVehicleWarningCount() {
+        _vehicleWarningCount.value += 1
+    }
+    
+    /**
      * 일시정지 (Atomic Update: isRunning과 pauseType을 동시에 변경)
      * UI가 한 번에 완벽한 상태로 그려지도록 보장합니다.
      */
@@ -92,6 +103,7 @@ object RunningStateManager {
         _isRunning.value = false
         _startTime.value = null
         _pauseType.value = PauseType.NONE
+        _vehicleWarningCount.value = 0 // 러닝 시작 시 0으로 리셋
     }
     
     // 러닝 시작 시간 설정 (첫 START 버튼 클릭 시)

--- a/shared/src/commonMain/kotlin/good/space/runnershi/viewmodel/RunningViewModel.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/viewmodel/RunningViewModel.kt
@@ -34,6 +34,7 @@ class RunningViewModel(
     val durationSeconds: StateFlow<Long> = RunningStateManager.durationSeconds
     val isRunning: StateFlow<Boolean> = RunningStateManager.isRunning
     val pauseType: StateFlow<PauseType> = RunningStateManager.pauseType
+    val vehicleWarningCount: StateFlow<Int> = RunningStateManager.vehicleWarningCount
 
     // 결과 화면 표시 여부 및 데이터
     private val _runResult = MutableStateFlow<RunResult?>(null)


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [ ] **Server**
- [x] **Android**
- [ ] **iOS**

## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
사용자의 속도가 너무 빨라 차량 이동 감지 횟수가 2회가 되면 러닝을 강제 종료하도록 개선했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #54 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
