### PR TITLE
fix(deploy): CI/CD 실패 해결을 위해 bootjar 중복 파일 생성시 전략 설정

### DIFF
--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.springframework.boot.gradle.tasks.bundling.BootJar
+
 plugins {
     alias(libs.plugins.kotlinJvm)
     alias(libs.plugins.kotlinSpring)
@@ -37,4 +39,8 @@ kotlin {
 
 tasks.withType<Test> {
     useJUnitPlatform()
+}
+
+tasks.named<BootJar>("bootJar") {
+    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 }


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [X] **Server**
- [ ] **Android**
- [ ] **iOS**

## ✨ 작업 내용
- 배포 파이프라인에서 의존성 라이브러리가 들어가는 폴더인 `BOOT-INF/lib/` 에 `library-desktop-1.7.1.jar` 파일이 중복 생성되는 버그를 발견했습니다. 이를 해결하기 위해 중복되는 파일이 생성될 때의 전략을 지정했습니다.

## 🔗 관련 이슈

## 💡 참고 사항
