### PR TITLE
feat(android): 홈에서 API를 무한 호출하던 버그 해결

### DIFF
--- a/shared/src/commonMain/kotlin/good/space/runnershi/App.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/App.kt
@@ -1,6 +1,7 @@
 package good.space.runnershi
 
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -112,16 +113,23 @@ fun App() {
                             userInfo = userInfo,
                             runResult = runResult,
                             onCloseClick = {
-                                // 홈 화면까지 모든 화면을 제거하고 홈으로 이동 (홈 화면은 유지)
-                                navController.navigate(Screen.Home.name) {
-                                    popUpTo(Screen.Home.name) { inclusive = false }
+                                // 홈 화면까지 모든 화면을 제거하고 홈으로 이동
+                                if (!navController.popBackStack(Screen.Home.name, inclusive = false)) {
+                                    // Home이 백스택에 없으면 navigate로 이동
+                                    navController.navigate(Screen.Home.name) {
+                                        popUpTo(Screen.Home.name) { inclusive = false }
+                                    }
                                 }
                             }
                         )
                     } else {
                         // 데이터가 없으면 홈으로 튕겨내기
-                        navController.navigate(Screen.Home.name) {
-                            popUpTo(Screen.Home.name) { inclusive = false }
+                        LaunchedEffect(Unit) {
+                            if (!navController.popBackStack(Screen.Home.name, inclusive = false)) {
+                                navController.navigate(Screen.Home.name) {
+                                    popUpTo(Screen.Home.name) { inclusive = false }
+                                }
+                            }
                         }
                     }
                 }

--- a/shared/src/commonMain/kotlin/good/space/runnershi/ui/home/HomeViewModel.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/ui/home/HomeViewModel.kt
@@ -24,6 +24,10 @@ class HomeViewModel(
     val uiState: StateFlow<HomeUiState> = _uiState.asStateFlow()
 
     fun fetchQuestData() {
+        if (_uiState.value.isLoading) {
+            return
+        }
+
         viewModelScope.launch {
             _uiState.update { it.copy(isLoading = true, errorMessage = null) }
 


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [ ] **Server**
- [x] **Android**
- [ ] **iOS**

## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
결과 화면에서 홈 화면으로 이동할 때, 컴포넌트가 무한히 재구성되며 계속 API를 호출하던 버그를 해결했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #115 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
