### PR TITLE
feat(android): 러닝 결과를 업로드하는 동안 사용자에게 로딩 중임을 표시

### DIFF
--- a/shared/src/commonMain/kotlin/good/space/runnershi/ui/running/RunningRoute.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/ui/running/RunningRoute.kt
@@ -22,9 +22,6 @@ fun RunningRoute(
     val focusManager = LocalFocusManager.current
     val permissionManager: LocationPermissionManager = koinInject()
     
-    // 권한 상태 구독
-    val hasPermission by permissionManager.hasPermission.collectAsState()
-    
     // 플랫폼별 권한 요청 처리
     HandleLocationPermission(permissionManager = permissionManager)
 
@@ -39,6 +36,7 @@ fun RunningRoute(
     val personalBest by viewModel.personalBest.collectAsState()
     val pauseType by viewModel.pauseType.collectAsState()
     val vehicleWarningCount by viewModel.vehicleWarningCount.collectAsState()
+    val uploadState by viewModel.uploadState.collectAsState()
 
     // 진입 시 키보드/포커스 정리 및 초기화
     LaunchedEffect(Unit) {
@@ -66,7 +64,8 @@ fun RunningRoute(
         isRunning = isRunning,
         personalBest = personalBest,
         pauseType = pauseType,
-        vehicleWarningCount = vehicleWarningCount
+        vehicleWarningCount = vehicleWarningCount,
+        uploadState = uploadState
     )
 
     // Side Effect 처리

--- a/shared/src/commonMain/kotlin/good/space/runnershi/ui/running/RunningScreen.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/ui/running/RunningScreen.kt
@@ -9,10 +9,13 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import good.space.runnershi.model.domain.location.LocationModel
 import good.space.runnershi.model.dto.running.LongestDistance
@@ -91,11 +94,40 @@ fun RunningScreen(
             onPauseResumeClick = onPauseResumeClick
         )
 
+        if (state.uploadState == UploadState.UPLOADING) {
+            LoadingOverlay()
+        }
+
         if (state.pauseType == PauseType.AUTO_PAUSE_VEHICLE) {
             VehicleWarningDialog(
                 isForcedStop = state.vehicleWarningCount > 1,
                 onResumeClick = onVehicleResumeClick,
                 onFinishClick = onForcedFinishClick
+            )
+        }
+    }
+}
+
+@Composable
+private fun LoadingOverlay() {
+    // 배경을 터치하지 못하게 Box가 전체를 채우고 clickable을 consume함
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(Color.Black.copy(alpha = 0.4f)) // 반투명 검정 배경
+            .pointerInput(Unit) {}, // 하위 뷰로 클릭 이벤트 전파 방지
+        contentAlignment = Alignment.Center
+    ) {
+        Column(horizontalAlignment = Alignment.CenterHorizontally) {
+            CircularProgressIndicator(
+                color = RunnersHiTheme.colorScheme.primary,
+                strokeWidth = 4.dp
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = "러닝 기록을 저장 중입니다...",
+                style = RunnersHiTheme.typography.bodyMedium,
+                color = Color.White
             )
         }
     }
@@ -119,7 +151,8 @@ private fun RunningScreenActivePreview() {
         currentPace = "6'20''",
         currentCalories = 350,
         isRunning = true,
-        personalBest = dummyPersonalBest
+        personalBest = dummyPersonalBest,
+        uploadState = UploadState.UPLOADING
     )
 
     RunnersHiTheme {
@@ -146,7 +179,8 @@ private fun RunningScreenPausedPreview() {
         currentPace = "-'--''",
         currentCalories = 0,
         isRunning = false,
-        personalBest = dummyPersonalBest
+        personalBest = dummyPersonalBest,
+        uploadState = UploadState.IDLE
     )
 
     RunnersHiTheme {

--- a/shared/src/commonMain/kotlin/good/space/runnershi/ui/running/RunningUiState.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/ui/running/RunningUiState.kt
@@ -14,5 +14,6 @@ data class RunningUiState(
     val isRunning: Boolean = false,
     val personalBest: LongestDistance? = null,
     val pauseType: PauseType = PauseType.NONE,
-    val vehicleWarningCount: Int = 0
+    val vehicleWarningCount: Int = 0,
+    val uploadState: UploadState
 )


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [ ] **Server**
- [x] **Android**
- [ ] **iOS**

## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
러닝을 종료하여 결과를 업로드하는 중임을 사용자가 알 수 있도록 로딩 바를 출력합니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #113 