### PR TITLE
feat(android): 퀘스트 카드의 제목이 너무 긴 경우 해결

### DIFF
--- a/shared/src/commonMain/kotlin/good/space/runnershi/ui/components/QuestCard.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/ui/components/QuestCard.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.shadow
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import good.space.runnershi.ui.theme.RunnersHiTheme
@@ -79,9 +80,12 @@ fun QuestCard(
                 Text(
                     text = title,
                     style = RunnersHiTheme.typography.titleMedium,
-                    fontSize = 18.sp,
+                    fontSize = 16.sp,
                     fontWeight = FontWeight.Bold,
-                    color = colorScheme.onBackground
+                    color = colorScheme.onBackground,
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.weight(1f)
                 )
 
                 // 경험치 or 체크표시
@@ -125,6 +129,9 @@ fun QuestListPreview() {
         Column(modifier = Modifier.padding(16.dp), verticalArrangement = Arrangement.spacedBy(12.dp)) {
             // 일반 퀘스트
             QuestCard(title = "3km 달리기", exp = 100, isCleared = false)
+
+            // 이름이 긴 퀘스트
+            QuestCard(title = "이름이짱긴달리기퀘스트입니다이름은과연몇글자까지될까", exp = 10000, isCleared = false)
 
             // 클리어된 퀘스트
             QuestCard(title = "15분 달리기", exp = 100, isCleared = true)


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [ ] **Server**
- [x] **Android**
- [ ] **iOS**

## ✨ 작업 내용
<!-- 작업 내용을 세분화해서 작성 -->
<!-- 예시
  - User에 name 속성을 추가했습니다.
  - 회원가입 시 이름이 비었는지에 대한 검증을 추가했습니다.
  - 회원의 나이가 1 이상임에 대한 검증을 추가했습니다.
-->
퀘스트 카드의 제목이 너무 길 경우, 내용이 여러 줄로 넘치는 대신 뒷 내용을 `...`으로 처리하도록 개선했습니다.

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->
- #125 

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->
