### PR TITLE
feat(server): add description field in Quest

### DIFF
--- a/server/src/main/kotlin/good/space/runnershi/quest/service/QuestService.kt
+++ b/server/src/main/kotlin/good/space/runnershi/quest/service/QuestService.kt
@@ -20,6 +20,7 @@ class QuestService(
         return user.dailyQuests.map { status ->
             QuestResponse(
                 title = status.quest.title,
+                description = status.quest.description,
                 exp = status.quest.exp,
                 isCompleted = status.isCompleted
             )

--- a/server/src/main/kotlin/good/space/runnershi/user/domain/Quest.kt
+++ b/server/src/main/kotlin/good/space/runnershi/user/domain/Quest.kt
@@ -8,12 +8,14 @@ import kotlin.time.ExperimentalTime
 @OptIn(ExperimentalTime::class)
 enum class Quest(
     val title: String,
+    val description: String,
     val level: Long,
     val available: (Running) -> Boolean,
     val exp: Long,
     val questId: Long
 ) {
     DISTANCE_LV1(
+        "러닝 거리 Lv1",
         "2Km 달리기",
         1,
         { running -> running.distanceMeters >= 2_000 },
@@ -22,6 +24,7 @@ enum class Quest(
     ),
 
     DURATION_LV1(
+        "러닝 시간 Lv1",
         "20분간 땀 흘리기",
         1,
         { running -> running.duration.inWholeMinutes >= 20 },
@@ -30,6 +33,7 @@ enum class Quest(
     ),
 
     MORNING_LV1(
+        "아침 러닝 Lv1",
         "오전 6~9시에 느끼는 상쾌한 시작",
         1,
         { running -> val hour = running.startedAt.toLocalDateTime(TimeZone.currentSystemDefault()).hour
@@ -40,6 +44,7 @@ enum class Quest(
     ),
 
     NONSTOP_LV1(
+        "논스탑 러닝 Lv1",
         "1000M 동안 멈추지 않는 심장",
         1,
         { running -> running.longestNonStopDistance >= 1_000},
@@ -48,6 +53,7 @@ enum class Quest(
     ),
 
     SPEED_LV1(
+        "페이스 Lv1",
         "1OOOM, 7분 페이스 주파",
         1,
         { running ->
@@ -59,6 +65,7 @@ enum class Quest(
     ),
 
     DISTANCE_LV2(
+        "러닝 거리 Lv2",
         "5km 챌린지",
         2,
         { run -> run.distanceMeters >= 5_000 },
@@ -67,6 +74,7 @@ enum class Quest(
     ),
 
     DURATION_LV2(
+        "러닝 시간 Lv2",
         "40분의 끈기",
         2,
         { run -> run.duration.inWholeMinutes >= 40 },
@@ -76,6 +84,7 @@ enum class Quest(
 
     // 3. 아침: 오전 5시~9시 사이에 '3km' 이상 러닝 (LV1은 거리제한 없었음 -> 거리 조건 추가)
     MORNING_LV2(
+        "아침 러닝 Lv2",
         "오전 5~9시 아침을 깨우는 3km",
         2,
         { run ->
@@ -88,6 +97,7 @@ enum class Quest(
 
     // 4. 휴식 최소화: 5km 이상 뛰면서
     NONSTOP_LV2(
+        "논스탑 러닝 Lv2",
         "멈추지 않는 5km",
         2,
         { run -> run.longestNonStopDistance >= 5_000 },
@@ -97,11 +107,12 @@ enum class Quest(
 
     // 5. 속도: 3km 이상, 평균 페이스 6분 00초/km 이하 (조깅 수준 탈피)
     SPEED_LV2(
+        "페이스 Lv2",
         "3키로, 6분 페이스 돌파",
         2,
         { run ->
             val paceSeconds = run.duration.inWholeSeconds / (run.distanceMeters / 1000.0)
-           run.distanceMeters >= 3_000 && paceSeconds <= 360
+            run.distanceMeters >= 3_000 && paceSeconds <= 360
         },
         400,
         205
@@ -114,6 +125,7 @@ enum class Quest(
 
     // 1. 거리: 10km 마라톤 연습
     DISTANCE_LV3(
+        "러닝 거리 Lv3",
         "10km 완주",
         3,
         { run -> run.distanceMeters >= 10_000 },
@@ -123,6 +135,7 @@ enum class Quest(
 
     // 2. 시간: 1시간(60분) 이상 러닝
     DURATION_LV3(
+        "러닝 시간 Lv3",
         "1시간의 몰입",
         3,
         { run -> run.duration.inWholeMinutes >= 60 },
@@ -132,6 +145,7 @@ enum class Quest(
 
     // 3. 아침: 오전 4시~8시 사이에 '5km' 이상 러닝 (미라클 모닝)
     MORNING_LV3(
+        "아침 러닝 Lv3",
         "오전 4~7시, 새벽을 여는 5km",
         3,
         { run ->
@@ -145,7 +159,8 @@ enum class Quest(
 
     // 4. 휴식 최소화: 10km 이상 뛰면서, 휴식 1분 미만 (거의 논스톱)
     NONSTOP_LV3(
-         "강철 심장 (10km 논스톱)",
+        "논스탑 러닝 Lv3",
+        "강철 심장 (10km 논스톱)",
         3,
         { run -> run.longestNonStopDistance >= 10_000 },
         800,
@@ -154,6 +169,7 @@ enum class Quest(
 
     // 5. 속도: 5km 이상, 평균 페이스 5분 00초/km 이하 (상급자 코스)
     SPEED_LV3(
+        "페이스 Lv3",
         "5km, 5분 페이스의 벽",
         3,
         { run ->

--- a/shared/src/commonMain/kotlin/good/space/runnershi/model/dto/user/QuestResponse.kt
+++ b/shared/src/commonMain/kotlin/good/space/runnershi/model/dto/user/QuestResponse.kt
@@ -5,6 +5,7 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class QuestResponse(
     val title: String,
+    val description: String,
     val exp: Long,
     val isCompleted: Boolean
 )


### PR DESCRIPTION
## 📝 모듈

- [ ] **Shared**
- [O] **Server**
- [ ] **Android**
- [ ] **iOS**

## ✨ 작업 내용

> 퀘스트 제목이 너무 길어서 뷰 개빡인데, 이름은 짧게 하고 description 속성으로 클리어 조건을 명시해주는건 어떨까요

라는 요청에 title은 간소화 및 통일, 원래 title은 description필드로 변경하였습니다. 

## 🔗 관련 이슈
<!-- 연관된 이슈의 번호를 기입 -->

## 💡 참고 사항
<!-- 다른 리뷰어들이 추가적으로 알아야 하는 정보 작성 -->

HomeScreen.kt 파일에서 컴파일 에러가 발생하고 있으니, 새로 추가한 Description속성을 추가해주셔야할 것 같습니다. title은 그대로 쓰시면 되어용 
